### PR TITLE
Docker debug changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,11 @@ RUN python -m pip install --upgrade pip && \
       cryptography paramiko pandas pynacl ecdsa sslyze pyjks pyelftools \
       python-dotenv pyyaml \
       azure-identity azure-mgmt-compute azure-mgmt-network \
-      ssh-audit
+      ssh-audit 
+
+# not for production
+#RUN pip install debugpy
+#EXPOSE 5678
 
 # App workspace
 WORKDIR /app

--- a/run_scan.py
+++ b/run_scan.py
@@ -3,6 +3,13 @@
 import json, os, runpy, sys
 from pathlib import Path
 
+# remove comment to enable debugpy, set breakpoints in VSCode
+import debugpy
+# Allow remote debugging and wait for a client to connect
+debugpy.listen(("0.0.0.0", 5678)) # Listen on all interfaces
+debugpy.wait_for_client()
+
+
 from dotenv import load_dotenv
 try:
     import yaml

--- a/run_scan.py
+++ b/run_scan.py
@@ -3,12 +3,13 @@
 import json, os, runpy, sys
 from pathlib import Path
 
+'''
 # remove comment to enable debugpy, set breakpoints in VSCode
 import debugpy
 # Allow remote debugging and wait for a client to connect
 debugpy.listen(("0.0.0.0", 5678)) # Listen on all interfaces
 debugpy.wait_for_client()
-
+'''
 
 from dotenv import load_dotenv
 try:


### PR DESCRIPTION
used debugpy to enable debugging.  There are two parts to this change.  

1) in Docker file,

RUN pip install debugpy
EXPOSE 5678

installs debugpy and exposes port that will be used to connect to docker image

2) in the python code

import debugpy
# Allow remote debugging and wait for a client to connect
debugpy.listen(("0.0.0.0", 5678)) # Listen on all interfaces
debugpy.wait_for_client()

this connects to the docker instance.  When you start debugging, the prompt should pause and wait until user continues to step to the next breakpoint